### PR TITLE
Systemd docker machine

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -40,7 +40,7 @@ cp /src/docker/contrib/init/sysvinit-debian/docker.default $PACKAGE_ROOT/etc/def
 mkdir -p $PACKAGE_ROOT/etc/init.d/
 # cp /src/docker/contrib/init/sysvinit-debian/docker $PACKAGE_ROOT/etc/init.d/docker
 mkdir -p $PACKAGE_ROOT/lib/systemd/system/
-cp /src/docker/contrib/init/systemd/docker.service $PACKAGE_ROOT/lib/systemd/system/
+# cp /src/docker/contrib/init/systemd/docker.service $PACKAGE_ROOT/lib/systemd/system/
 cp /src/docker/contrib/init/systemd/docker.socket $PACKAGE_ROOT/lib/systemd/system/
 mkdir -p $PACKAGE_ROOT/etc/bash_completion.d
 cp /src/docker/contrib/completion/bash/docker $PACKAGE_ROOT/etc/bash_completion.d/docker

--- a/pkg-debian/lib/systemd/system/docker.service
+++ b/pkg-debian/lib/systemd/system/docker.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+ExecStart=/usr/bin/docker -d -H fd://
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg-debian/lib/systemd/system/docker.service
+++ b/pkg-debian/lib/systemd/system/docker.service
@@ -5,7 +5,8 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker -d -H fd://
+ExecStart=/usr/bin/docker -d -H fd:// $DOCKER_OPTS
+EnvironmentFile=-/etc/default/docker
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
I tried to get this merged on official Docker repo: https://github.com/docker/docker/pull/14319

They are against because:

- using this, won't support HTTP_PROXY headers for instance
- systemd discourage package manager to handle this and encourage distrib managers to do

I'm actually using it on the official Scaleway Docker image: https://github.com/scaleway/image-app-docker/blob/master/patches/etc/systemd/system/docker.service

If you want to merge it, I can fully depend on your package, else I will keep this file to stay `docker-machine` compatible