### PR TITLE
Apply PR opencontainers/runc#70 to test docker 1.8.0-rc3 on RPi.

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -28,6 +28,13 @@ export AUTO_GOPATH=1
 # see https://github.com/vishvananda/netns/pull/8
 #sed -i s/374/375/g /src/docker/vendor/src/github.com/vishvananda/netns/netns_linux_arm.go
 #---FIX
+#+++FIX: 1.8.0-rc3
+echo "Applying PR opencontainers/runc#70 ..."
+pushd vendor/src/github.com/opencontainers
+rm -rf runc
+git clone --depth 1 --branch seccomp https://github.com/mheon/runc.git
+popd
+#---FIX
 GOARM=6 ./hack/make.sh dynbinary
 
 # create tarball with Docker binaries

--- a/run-builder.sh
+++ b/run-builder.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -x
 mkdir -p dist
 touch .env
-docker run --rm=true --env-file=.env -v $(pwd)/builder.sh:/builder.sh -v $(pwd)/pkg-debian:/pkg-debian -v $(pwd)/dist:/dist hypriot/rpi-docker-builder /builder.sh 1.7.1 -2
+docker run --rm=true --env-file=.env -v $(pwd)/builder.sh:/builder.sh -v $(pwd)/pkg-debian:/pkg-debian -v $(pwd)/dist:/dist hypriot/rpi-docker-builder /builder.sh 1.8.0-rc3 -1


### PR DESCRIPTION
I've just compiled Docker 1.8.0-rc3 on a Raspberry Pi by applying the PR opencontainers/runc#70
Perhaps there is a better way by updating Godeps, but cloning the PR worked fine for me.
